### PR TITLE
Update trainer.py

### DIFF
--- a/flair/trainers/trainer.py
+++ b/flair/trainers/trainer.py
@@ -562,7 +562,7 @@ class ModelTrainer(Pluggable):
             self.context_stack = context_stack
             self.dispatch("after_setup", **parameters)
 
-            scaler = torch.cuda.amp.GradScaler(enabled=use_amp and flair.device.type != "cpu")
+            scaler = torch.amp.GradScaler('cuda', enabled=use_amp and flair.device.type != "cpu")
 
             final_eval_info = (
                 "model after last epoch (final-model.pt)"


### PR DESCRIPTION
Fix deprecation warning in Flair's trainer code. The issue is that: Flair is using the old PyTorch AMP (Automatic Mixed Precision) API.